### PR TITLE
feat(googleiap): ZEUS-1086 - Add autoRenewing flag in the Android IAP verify request schema

### DIFF
--- a/reference/CloudPay-API-Specification.yaml
+++ b/reference/CloudPay-API-Specification.yaml
@@ -1520,6 +1520,7 @@ paths:
                     purchaseIdentifier: a-purchase-token-123
                     packageName: a-package-name
                     productId: a-product-id-456
+                    autoRenewing: true
                   platform: android
               roku-example:
                 value:

--- a/reference/CloudPay-API-Specification.yaml
+++ b/reference/CloudPay-API-Specification.yaml
@@ -1292,7 +1292,7 @@ paths:
         - $ref: '#/components/parameters/apiJwtTokenParam'
         - $ref: '#/components/parameters/apiSessionIdParam'
         - $ref: '#/components/parameters/thirdPartyAuthCookie'
-        - $ref: '#/components/parameters/authCookie'    
+        - $ref: '#/components/parameters/authCookie'
       responses:
         '200':
           description: OK
@@ -1494,6 +1494,8 @@ paths:
                       type: string
                     productId:
                       type: string
+                    autoRenewing:
+                      type: boolean
                     raw:
                       type: string
                       format: base64


### PR DESCRIPTION
The 'autoRenewing' flag will be used by the IAP verify lambda to determine which URL to invoke for Android receipt verification.