### PR TITLE
feat(valida-drm): KRON-430 add validate drm endpoint

### DIFF
--- a/reference/CloudPay-API-Specification.yaml
+++ b/reference/CloudPay-API-Specification.yaml
@@ -21,6 +21,7 @@ tags:
   - name: Models
   - name: User
   - name: Resume
+  - name: DRM
 paths:
   /sso/start:
     get:
@@ -2506,6 +2507,101 @@ paths:
           in: cookie
           name: thirdpartyauthentication
           description: The authentication Cookie
+  /api/v1/validatedrm/{entryId}/{customerId}:
+    get:
+      summary: Validate a customer access to the MediaPlatform entry
+      tags:
+        - DRM
+      parameters:
+        - in: path
+          name: entryId
+          schema:
+            type: string
+            minLength: 1
+          required: true
+          description: The entry id
+        - in: path
+          name: customerId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: The customer id  
+      responses:
+        '200':
+          description: |-
+            Validation request responses
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  example-1:
+                    Granted: false
+                    Reason: Invalid customer id
+                properties:
+                  Granted:
+                    type: boolean
+                  Reason:
+                    type: string
+                    nullable: true       
+                required:
+                  - Granted
+              examples:
+                Customer account is granted:
+                  value:
+                    Granted: true     
+                Customer account is blocked:
+                  value:
+                    Granted: false
+                    Reason: Account blocked  
+                Customer account don't have an active session:
+                  value:
+                    Granted: false
+                    Reason: No active session
+                Customer account don't have valid entitlements:
+                  value:
+                    Granted: false
+                    Reason: No entitlement
+                Customer account don't have valid subscription:
+                  value:
+                    Granted: false
+                    Reason: No subscription
+                Unknown reason, includes CardAuthenticationRequired but doesn't include ConcurrencyCheck:
+                  value:
+                    Granted: false
+                    Reason: Unknown reason    
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  Granted: 
+                    type: boolean
+                  Reason:
+                    type: string
+                required:
+                  - Granted
+                  - Reason
+                x-examples:
+                  example-1:
+                    Granted: false
+                    Reason: Unknown reason
+              examples:
+                Unknown reason:
+                  value:
+                    Granted: false
+                    Reason: Unknown reason
+      description: |-
+        In order to validate that a customer has an access to the media entry.
+
+        A customer should have a valid session (Freemium and Premium) and a correct paid subscription (entitlements) for Premium content.
+
+      operationId: validate-drm
+    parameters: []
 components:
   parameters:
     languageParam:

--- a/reference/CloudPay-API-Specification.yaml
+++ b/reference/CloudPay-API-Specification.yaml
@@ -2512,6 +2512,7 @@ paths:
       summary: Validate a customer access to the MediaPlatform entry
       tags:
         - DRM
+      x-internal: true  
       parameters:
         - in: path
           name: entryId

--- a/reference/CloudPay-API-Specification.yaml
+++ b/reference/CloudPay-API-Specification.yaml
@@ -2535,10 +2535,6 @@ paths:
             application/json:
               schema:
                 type: object
-                x-examples:
-                  example-1:
-                    Granted: false
-                    Reason: Invalid customer id
                 properties:
                   Granted:
                     type: boolean
@@ -2550,11 +2546,15 @@ paths:
               examples:
                 Customer account is granted:
                   value:
-                    Granted: true     
+                    Granted: true
+                Entry entitlements error:
+                  value:
+                    Granted: false
+                    Reason: Entry entitlements error     
                 Customer account is blocked:
                   value:
                     Granted: false
-                    Reason: Account blocked  
+                    Reason: Customer is blocked or deleted  
                 Customer account don't have an active session:
                   value:
                     Granted: false
@@ -2562,15 +2562,39 @@ paths:
                 Customer account don't have valid entitlements:
                   value:
                     Granted: false
-                    Reason: No entitlement
+                    Reason: No entitlements
                 Customer account don't have valid subscription:
                   value:
                     Granted: false
                     Reason: No subscription
-                Unknown reason, includes CardAuthenticationRequired but doesn't include ConcurrencyCheck:
+                Customer payment card requires authorization:
                   value:
                     Granted: false
-                    Reason: Unknown reason    
+                    Reason: Customer payment card requires authorization
+                Customer data error:
+                  value:
+                    Granted: false
+                    Reason: Customer error       
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  Granted: 
+                    type: boolean
+                  Reason:
+                    type: string
+                required:
+                  - Granted
+                  - Reason
+              examples:
+                Invalid customer id:
+                  value:
+                    Granted: false
+                    Reason: BadRequestException
         '500':
           description: Internal server error
           content:
@@ -2586,15 +2610,11 @@ paths:
                 required:
                   - Granted
                   - Reason
-                x-examples:
-                  example-1:
-                    Granted: false
-                    Reason: Unknown reason
               examples:
                 Unknown reason:
                   value:
                     Granted: false
-                    Reason: Unknown reason
+                    Reason: Exception name
       description: |-
         In order to validate that a customer has an access to the media entry.
 


### PR DESCRIPTION
Adding /api/v1/validatedrm/{entryId}/{customerId}
To discuss about server domain - payments or other
To discuss about that Granted: false to be with status 200 too.
To discuss about a different response because current respose cover existed endpoint but we can change always
e.g. {
Granted: false,
Reason: No Entitlements
}